### PR TITLE
feat: prompt to enable WiFi on server start and update check

### DIFF
--- a/filesync/filesyncmanager.lua
+++ b/filesync/filesyncmanager.lua
@@ -194,67 +194,83 @@ function FileSyncManager:start(silent)
         return
     end
 
-    -- Check WiFi
-    if not NetworkMgr:isWifiOn() then
-        if not silent then
-            UIManager:show(InfoMessage:new{
-                text = _("WiFi is not enabled. Please turn on WiFi first."),
-                timeout = 3,
-            })
+    -- Continuation: runs once WiFi is confirmed up (or immediately, if it
+    -- already was). Kept local to start() so it can close over `silent`.
+    local function continueStart()
+        -- Re-entrancy guard: an auto-start could have fired between the
+        -- WiFi prompt and the connectivity callback.
+        if self._running then return end
+
+        -- Get the local IP. NetworkMgr:runWhenConnected only guarantees
+        -- isConnected (IP + gateway), so the IP lookup may still fail on
+        -- some devices; keep the existing retry/fallback chain.
+        local ip = self:getLocalIP()
+        if not ip then
+            if not silent then
+                UIManager:show(InfoMessage:new{
+                    text = _("Could not determine device IP address. Make sure WiFi is connected."),
+                    timeout = 3,
+                })
+            end
+            return
         end
+
+        local port = self:getPort()
+        local root_dir = self:getRootDir()
+
+        -- Start the HTTP server
+        local HttpServer = require("filesync/httpserver")
+        local ok, err = pcall(function()
+            self._server = HttpServer:new{
+                port = port,
+                root_dir = root_dir,
+            }
+            self._server:start()
+        end)
+
+        if not ok then
+            logger.err("FileSync: Failed to start server:", err)
+            if not silent then
+                UIManager:show(InfoMessage:new{
+                    text = T(_("Failed to start server: %1"), tostring(err)),
+                    timeout = 5,
+                })
+            end
+            return
+        end
+
+        -- Add Kindle firewall rules
+        if Device:isKindle() then
+            self:openKindleFirewall(port)
+        end
+
+        self._running = true
+        self._ip = ip
+        self._port = port
+        self:preventStandby()
+        logger.info("FileSync: Server started on", ip .. ":" .. port)
+
+        if not silent then
+            self:showQRCode()
+        end
+    end
+
+    -- WiFi gate. In silent mode (auto-start on resume) we never want to
+    -- pop KOReader's "Turn on Wi-Fi?" prompt, so just bail if WiFi is off.
+    -- In interactive mode, defer to NetworkMgr: if already connected,
+    -- runWhenConnected fires the callback inline; otherwise it shows the
+    -- standard prompt and schedules the callback after IP is assigned.
+    -- If the user cancels the prompt, the callback simply never fires
+    -- and no error is shown -- which is what we want.
+    if not NetworkMgr:isConnected() then
+        if silent then
+            return
+        end
+        NetworkMgr:runWhenConnected(continueStart)
         return
     end
 
-    -- Get the local IP
-    local ip = self:getLocalIP()
-    if not ip then
-        if not silent then
-            UIManager:show(InfoMessage:new{
-                text = _("Could not determine device IP address. Make sure WiFi is connected."),
-                timeout = 3,
-            })
-        end
-        return
-    end
-
-    local port = self:getPort()
-    local root_dir = self:getRootDir()
-
-    -- Start the HTTP server
-    local HttpServer = require("filesync/httpserver")
-    local ok, err = pcall(function()
-        self._server = HttpServer:new{
-            port = port,
-            root_dir = root_dir,
-        }
-        self._server:start()
-    end)
-
-    if not ok then
-        logger.err("FileSync: Failed to start server:", err)
-        if not silent then
-            UIManager:show(InfoMessage:new{
-                text = T(_("Failed to start server: %1"), tostring(err)),
-                timeout = 5,
-            })
-        end
-        return
-    end
-
-    -- Add Kindle firewall rules
-    if Device:isKindle() then
-        self:openKindleFirewall(port)
-    end
-
-    self._running = true
-    self._ip = ip
-    self._port = port
-    self:preventStandby()
-    logger.info("FileSync: Server started on", ip .. ":" .. port)
-
-    if not silent then
-        self:showQRCode()
-    end
+    continueStart()
 end
 
 --- Stop the FileSync server: close QR screen, stop HttpServer, remove firewall rules.

--- a/filesync/updater.lua
+++ b/filesync/updater.lua
@@ -307,80 +307,85 @@ function Updater:checkForUpdates()
     local InfoMessage = require("ui/widget/infomessage")
     local NetworkMgr = require("ui/network/manager")
 
-    -- Check network availability
-    if not NetworkMgr:isWifiOn() then
-        UIManager:show(InfoMessage:new{
-            text = _("WiFi is not enabled. Please turn on WiFi and try again."),
-            timeout = 3,
-        })
-        return
+    -- Continuation: runs once the device is online (WAN reachable, since
+    -- we need to talk to api.github.com over HTTPS). Kept local so it
+    -- closes over the locals above.
+    local function runCheck()
+        -- Show a brief "checking" message
+        local checking_msg = InfoMessage:new{
+            text = _("Checking for updates..."),
+            timeout = 30,
+        }
+        UIManager:show(checking_msg)
+        UIManager:forceRePaint()
+
+        -- Perform the check in a scheduled callback to allow the UI to render
+        UIManager:scheduleIn(0.1, function()
+            local release, err = self:_fetchLatestRelease()
+
+            -- Close the "checking" message
+            if checking_msg then
+                UIManager:close(checking_msg)
+            end
+
+            if not release then
+                logger.warn("FileSync Updater:", err)
+                UIManager:show(InfoMessage:new{
+                    text = T(_("Could not check for updates.\n\n%1"), err),
+                    timeout = 5,
+                })
+                return
+            end
+
+            local remote_version_str = release.tag_name
+            if not remote_version_str then
+                UIManager:show(InfoMessage:new{
+                    text = _("Could not determine the latest version."),
+                    timeout = 3,
+                })
+                return
+            end
+
+            local current_version_str = self:_getCurrentVersion()
+            local remote_ver = self:_parseVersion(remote_version_str)
+            local local_ver = self:_parseVersion(current_version_str)
+
+            if not self:_isNewer(remote_ver, local_ver) then
+                UIManager:show(InfoMessage:new{
+                    text = T(_("FileSync is up to date (v%1)."), current_version_str),
+                    timeout = 3,
+                })
+                return
+            end
+
+            -- A new version is available — prompt the user
+            local display_version = remote_version_str:gsub("^v", "")
+            local changelog = self:_getChangelog(release)
+            local message = T(_("A new version of FileSync is available!\n\nCurrent: v%1\nNew: v%2"), current_version_str, display_version)
+            if changelog ~= "" then
+                message = message .. "\n\n" .. changelog
+            end
+
+            local ConfirmBox = require("ui/widget/confirmbox")
+            UIManager:show(ConfirmBox:new{
+                text = message,
+                ok_text = _("Update now"),
+                cancel_text = _("Later"),
+                ok_callback = function()
+                    self:_performUpdate(release)
+                end,
+            })
+        end)
     end
 
-    -- Show a brief "checking" message
-    local checking_msg = InfoMessage:new{
-        text = _("Checking for updates..."),
-        timeout = 30,
-    }
-    UIManager:show(checking_msg)
-    UIManager:forceRePaint()
-
-    -- Perform the check in a scheduled callback to allow the UI to render
-    UIManager:scheduleIn(0.1, function()
-        local release, err = self:_fetchLatestRelease()
-
-        -- Close the "checking" message
-        if checking_msg then
-            UIManager:close(checking_msg)
-        end
-
-        if not release then
-            logger.warn("FileSync Updater:", err)
-            UIManager:show(InfoMessage:new{
-                text = T(_("Could not check for updates.\n\n%1"), err),
-                timeout = 5,
-            })
-            return
-        end
-
-        local remote_version_str = release.tag_name
-        if not remote_version_str then
-            UIManager:show(InfoMessage:new{
-                text = _("Could not determine the latest version."),
-                timeout = 3,
-            })
-            return
-        end
-
-        local current_version_str = self:_getCurrentVersion()
-        local remote_ver = self:_parseVersion(remote_version_str)
-        local local_ver = self:_parseVersion(current_version_str)
-
-        if not self:_isNewer(remote_ver, local_ver) then
-            UIManager:show(InfoMessage:new{
-                text = T(_("FileSync is up to date (v%1)."), current_version_str),
-                timeout = 3,
-            })
-            return
-        end
-
-        -- A new version is available — prompt the user
-        local display_version = remote_version_str:gsub("^v", "")
-        local changelog = self:_getChangelog(release)
-        local message = T(_("A new version of FileSync is available!\n\nCurrent: v%1\nNew: v%2"), current_version_str, display_version)
-        if changelog ~= "" then
-            message = message .. "\n\n" .. changelog
-        end
-
-        local ConfirmBox = require("ui/widget/confirmbox")
-        UIManager:show(ConfirmBox:new{
-            text = message,
-            ok_text = _("Update now"),
-            cancel_text = _("Later"),
-            ok_callback = function()
-                self:_performUpdate(release)
-            end,
-        })
-    end)
+    -- Network gate. checkForUpdates is only ever invoked from the
+    -- "Check for updates" menu item, so it's always interactive.
+    -- runWhenOnline runs the callback immediately if already online,
+    -- otherwise it triggers KOReader's standard Wi-Fi prompt and fires
+    -- the callback after WAN reachability is confirmed. If the user
+    -- cancels the prompt, runCheck simply never runs and no error is
+    -- shown.
+    NetworkMgr:runWhenOnline(runCheck)
 end
 
 --- Download and install an update from the given release.


### PR DESCRIPTION
## Summary

- When starting the FileSync server with WiFi off, route through KOReader's standard "Turn on Wi-Fi?" prompt via `NetworkMgr:runWhenConnected` instead of showing a dead-end warning. The server starts automatically once the user accepts.
- The update check uses `NetworkMgr:runWhenOnline` (WAN required for `api.github.com`) for the same flow.
- Silent auto-start (e.g. on resume) still bails quietly when WiFi is off — no prompt is popped in non-interactive paths.
- User cancellation of the WiFi prompt is a silent no-op; no error toast.

## Implementation notes

- Both call sites extract their post-WiFi body into a local closure (`continueStart` / `runCheck`) and pass it as the `NetworkMgr` callback. This keeps the existing IP-fallback chain, Kindle firewall handling, standby-prevent, and QR display intact.
- Added a re-entrancy guard in `continueStart` so a concurrent silent auto-start can't double-create the server while the WiFi prompt is up.
- Removed the now-unused English warning strings (`"WiFi is not enabled..."`); `.po` files will be cleaned up on the next i18n extraction.