### PR TITLE
fix: pass release notes via env var to survive shell quoting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,11 @@ jobs:
       - name: Create tag and GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ inputs.release_description }}
         run: |
           git tag "v${{ inputs.version }}"
           git push origin "v${{ inputs.version }}"
           gh release create "v${{ inputs.version }}" \
             --title "v${{ inputs.version }}" \
-            --notes "${{ inputs.release_description }}" \
+            --notes "$RELEASE_NOTES" \
             filesync.koplugin.zip


### PR DESCRIPTION
## Summary

The `Create tag and GitHub Release` step in `.github/workflows/release.yml` interpolates `release_description` directly into the shell command via `${{ inputs.release_description }}`. Because that substitution happens *before* the shell parses the line, any `"` or shell metacharacter in the user-supplied notes breaks `gh release create` with a parse error (e.g. `no matches found for `on`` when notes contain `"Turn on Wi-Fi?"`).

This PR moves `release_description` into the step's `env:` block and references it as `"$RELEASE_NOTES"` inside the shell, which is the standard pattern for safely passing untrusted input into a workflow shell step. The `version` input is already regex-validated upstream and does not need this treatment.

## Background

The previous v1.6.0 dispatch failed at this step; the version-bump commit and `v1.6.0` tag pushed successfully but the GitHub Release had to be created manually after the fact. Two of the last three release runs failed for the same root cause.