### PR TITLE
docs: Make README more generic about supported devices

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,7 +4,7 @@
 
 Ein KOReader-Plugin, das einen lokalen Webserver auf Ihrem E-Reader startet und einen QR-Code auf dem Bildschirm anzeigt. Scannen Sie den Code mit Ihrem Smartphone, um eine ansprechende Weboberfläche zur kabellosen Verwaltung Ihrer Bücher und Dateien zu öffnen — keine Kabel, keine Apps, nur Ihr Browser.
 
-Funktioniert auf **Kindle**- und **Kobo**-Geräten mit KOReader.
+Funktioniert auf Geräten mit KOReader (entwickelt für **Kindle** und **Kobo**).
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="QR-Code-Anzeige auf dem E-Reader" width="500">
@@ -46,7 +46,7 @@ Funktioniert auf **Kindle**- und **Kobo**-Geräten mit KOReader.
 
 ### Voraussetzungen
 
-- Ein Kindle- oder Kobo-E-Reader mit installiertem [KOReader](https://github.com/koreader/koreader)
+- Ein Gerät mit installiertem [KOReader](https://github.com/koreader/koreader)
 - E-Reader und Smartphone im selben WiFi-Netzwerk
 
 ### Option 1: Aus dem Release-Archiv (empfohlen)

--- a/README.es.md
+++ b/README.es.md
@@ -4,7 +4,7 @@
 
 Un plugin para KOReader que inicia un servidor web local en tu lector electrónico y muestra un código QR en pantalla. Escanea el código con tu teléfono para abrir una interfaz web elegante que te permite gestionar libros y archivos de forma inalámbrica — sin cables, sin apps, solo tu navegador.
 
-Funciona en dispositivos **Kindle** y **Kobo** con KOReader instalado.
+Funciona en dispositivos con KOReader instalado (diseñado para **Kindle** y **Kobo**).
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="Código QR en la pantalla del lector electrónico" width="500">
@@ -46,7 +46,7 @@ Funciona en dispositivos **Kindle** y **Kobo** con KOReader instalado.
 
 ### Requisitos previos
 
-- Un lector electrónico Kindle o Kobo con [KOReader](https://github.com/koreader/koreader) instalado
+- Un dispositivo con [KOReader](https://github.com/koreader/koreader) instalado
 - Tu lector electrónico y tu teléfono conectados a la misma red WiFi
 
 ### Opción 1: Desde el archivo de lanzamiento (Recomendado)

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,7 +4,7 @@
 
 Un plugin KOReader qui lance un serveur web local sur votre liseuse et affiche un QR code à l'écran. Scannez le code avec votre téléphone pour ouvrir une interface web soignée permettant de gérer vos livres et fichiers sans fil — pas de câbles, pas d'applications, juste votre navigateur.
 
-Fonctionne sur les appareils **Kindle** et **Kobo** sous KOReader.
+Fonctionne sur les appareils sous KOReader (conçu pour **Kindle** et **Kobo**).
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="Écran du QR code sur la liseuse" width="500">
@@ -46,7 +46,7 @@ Fonctionne sur les appareils **Kindle** et **Kobo** sous KOReader.
 
 ### Prérequis
 
-- Une liseuse Kindle ou Kobo avec [KOReader](https://github.com/koreader/koreader) installé
+- Un appareil avec [KOReader](https://github.com/koreader/koreader) installé
 - Votre liseuse et votre téléphone connectés au même réseau WiFi
 
 ### Option 1 : Depuis l'archive de la version (recommandé)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A KOReader plugin that launches a local web server on your e-reader and displays a QR code on screen. Scan the code with your phone to open a polished web interface for managing books and files wirelessly — no cables, no apps, just your browser.
 
-Works on **Kindle** and **Kobo** devices running KOReader.
+Works on devices running KOReader (designed for **Kindle** and **Kobo**).
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="QR code screen on e-reader" width="500">
@@ -46,7 +46,7 @@ Works on **Kindle** and **Kobo** devices running KOReader.
 
 ### Prerequisites
 
-- A Kindle or Kobo e-reader with [KOReader](https://github.com/koreader/koreader) installed
+- A device with [KOReader](https://github.com/koreader/koreader) installed
 - Both your e-reader and phone on the same WiFi network
 
 ### Option 1: From Release Archive (Recommended)

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -4,7 +4,7 @@
 
 Um plugin para KOReader que inicia um servidor web local no seu leitor eletrônico e exibe um código QR na tela. Escaneie o código com seu celular para abrir uma interface web completa que permite gerenciar livros e arquivos sem fio — sem cabos, sem aplicativos, apenas o seu navegador.
 
-Funciona em dispositivos **Kindle** e **Kobo** com KOReader instalado.
+Funciona em dispositivos com KOReader instalado (projetado para **Kindle** e **Kobo**).
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="Código QR na tela do leitor eletrônico" width="500">
@@ -46,7 +46,7 @@ Funciona em dispositivos **Kindle** e **Kobo** com KOReader instalado.
 
 ### Pré-requisitos
 
-- Um leitor eletrônico Kindle ou Kobo com [KOReader](https://github.com/koreader/koreader) instalado
+- Um dispositivo com [KOReader](https://github.com/koreader/koreader) instalado
 - Seu leitor eletrônico e celular conectados à mesma rede WiFi
 
 ### Opção 1: Pelo arquivo de lançamento (Recomendado)


### PR DESCRIPTION
The README specifically states this plugin supports Kindle and Kobo devices. This is inaccurate as Pocketbook and Android are also explicitly supported in the code, while any other device may work too. I could test it working fine on Pocketbook and Android.

Change the README to be more generic on the requirement (any device with KOReader, but designed for the two above).
I only updated the languages I can understand to some extent.