### PR TITLE
fix: add non-touch device support to the QR code screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A KOReader plugin that launches a local web server on your e-reader and displays a QR code on screen. Scan the code with your phone to open a polished web interface for managing books and files wirelessly — no cables, no apps, just your browser.
 
-Works on devices running KOReader (designed for **Kindle** and **Kobo**).
+Works on devices running KOReader (designed for **Kindle** and **Kobo**), including non-touch, keypad-only e-readers — the on-device screens are fully operable with the D-pad and physical keys.
 
 <p align="center">
   <img src="screenshots/qr-screen.png" alt="QR code screen on e-reader" width="500">
@@ -33,6 +33,7 @@ Works on devices running KOReader (designed for **Kindle** and **Kobo**).
 - **Sleep Prevention** — Keeps device awake and WiFi alive while the server runs
 - **Safe Mode** — Show only books and images, hiding system files
 - **Responsive UI** — Designed for smartphones, works on any screen
+- **Touch and Key Navigation** — On-device screens work with taps or with the D-pad/physical keys on non-touch readers
 
 ## How It Works
 

--- a/filesync/filesyncmanager.lua
+++ b/filesync/filesyncmanager.lua
@@ -5,14 +5,15 @@
 --- Key dependencies: device (KOReader), UIManager (KOReader), filesync/httpserver
 
 local Blitbuffer = require("ffi/blitbuffer")
+local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local ConfirmBox = require("ui/widget/confirmbox")
 local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
 local FrameContainer = require("ui/widget/container/framecontainer")
 local Geom = require("ui/geometry")
 local GestureRange = require("ui/gesturerange")
 local InfoMessage = require("ui/widget/infomessage")
-local InputContainer = require("ui/widget/container/inputcontainer")
 local NetworkMgr = require("ui/network/manager")
 local OverlapGroup = require("ui/widget/overlapgroup")
 local QRWidget = require("ui/widget/qrwidget")
@@ -373,6 +374,39 @@ function FileSyncManager:closeQRScreen()
     end
 end
 
+--- Stop the server from the QR screen: close it, show feedback, then stop and restart.
+--- Shared by the "Stop Server" button and the confirmation dialog.
+function FileSyncManager:stopFromQRScreen()
+    self:closeQRScreen()
+    UIManager:show(InfoMessage:new{
+        text = _("Stopping server..."),
+        timeout = 2,
+    })
+    -- Schedule the actual stop+restart after a brief moment so the
+    -- InfoMessage renders on the e-ink screen before the restart
+    UIManager:scheduleIn(0.5, function()
+        self:stop(true)
+        UIManager:restartKOReader()
+    end)
+end
+
+--- Ask the user what to do when leaving the QR screen while the server runs.
+--- Shared by the close button and the Back key.
+function FileSyncManager:confirmLeaveQRScreen()
+    UIManager:show(ConfirmBox:new{
+        title = _("File server is running"),
+        text = _("The server will keep running in the background and prevent the device from sleeping. What would you like to do?"),
+        ok_text = _("Stop server"),
+        cancel_text = _("Keep running"),
+        ok_callback = function()
+            self:stopFromQRScreen()
+        end,
+        cancel_callback = function()
+            self:closeQRScreen()
+        end,
+    })
+end
+
 --- Display a full-screen QR code with the server URL, stop button, and close button.
 --- Requires the server to be running (with a valid IP address).
 function FileSyncManager:showQRCode()
@@ -390,6 +424,18 @@ function FileSyncManager:showQRCode()
     local url = "http://" .. self._ip .. ":" .. self._port
     local screen_width = Screen:getWidth()
     local screen_height = Screen:getHeight()
+    local manager = self
+
+    -- The popup is a FocusManager so that D-pad devices can move focus between
+    -- the buttons below; it is created up-front because the ButtonTables need
+    -- it as their show_parent.
+    local widget = FocusManager:new{
+        name = "filesync_qrcode",
+        covers_fullscreen = true, -- hint for UIManager:_repaint()
+        width = screen_width,
+        height = screen_height,
+        layout = {},
+    }
 
     -- Build the QR code widget
     local qr_size = Screen:scaleBySize(260)
@@ -429,29 +475,48 @@ function FileSyncManager:showQRCode()
         max_width = screen_width - Screen:scaleBySize(40),
     }
 
-    -- Instructions text
+    -- Instructions text. On devices with physical keys we append a hint about
+    -- how to drive this screen without a touchscreen.
+    local instructions_text = _("Scan the QR code or enter the URL\nin your browser.\n\nBoth devices must be on the same WiFi network.")
+    if Device:hasDPad() then
+        instructions_text = instructions_text .. "\n\n"
+            .. _("Use the arrow keys to select a button and press the centre key to activate it. Press Back to leave this screen.")
+    elseif Device:hasKeys() then
+        instructions_text = instructions_text .. "\n\n" .. _("Press Back to leave this screen.")
+    end
     local instructions_widget = TextBoxWidget:new{
-        text = _("Scan the QR code or enter the URL\nin your browser.\n\nBoth devices must be on the same WiFi network."),
+        text = instructions_text,
         face = Font:getFace("smallinfofont", 20),
         width = screen_width * 0.65,
         alignment = "center",
         fgcolor = Blitbuffer.COLOR_BLACK,
     }
 
-    -- Stop Server button
-    local button_text = TextWidget:new{
-        text = _("Stop Server"),
-        face = Font:getFace("infofont", 20),
-        fgcolor = Blitbuffer.COLOR_BLACK,
+    -- Stop Server button. Built as a real ButtonTable so it is tappable *and*
+    -- focusable/activatable with the D-pad; the FrameContainer around it only
+    -- restores the bordered look of the previous hand-rolled button.
+    local stop_button_table = ButtonTable:new{
+        width = Screen:scaleBySize(240),
+        buttons = {
+            {
+                {
+                    text = _("Stop Server"),
+                    font_face = "infofont",
+                    font_size = 20,
+                    callback = function()
+                        manager:stopFromQRScreen()
+                    end,
+                },
+            },
+        },
+        show_parent = widget,
     }
     local stop_button = FrameContainer:new{
         bordersize = Size.border.button,
         radius = Size.radius.button,
-        padding = Screen:scaleBySize(10),
-        padding_left = Screen:scaleBySize(30),
-        padding_right = Screen:scaleBySize(30),
+        padding = Screen:scaleBySize(6),
         background = Blitbuffer.COLOR_WHITE,
-        button_text,
+        stop_button_table,
     }
 
     -- Vertical layout
@@ -469,20 +534,29 @@ function FileSyncManager:showQRCode()
         stop_button,
     }
 
-    -- X (close) button in the top-right corner
-    local close_button_text = TextWidget:new{
-        text = "\u{00D7}", -- multiplication sign as X
-        face = Font:getFace("infofont", 32),
-        fgcolor = Blitbuffer.COLOR_BLACK,
+    -- X (close) button in the top-right corner, also a real ButtonTable button
+    local close_button_table = ButtonTable:new{
+        width = Screen:scaleBySize(64),
+        buttons = {
+            {
+                {
+                    text = "\u{00D7}", -- multiplication sign as X
+                    font_face = "infofont",
+                    font_size = 32,
+                    callback = function()
+                        manager:confirmLeaveQRScreen()
+                    end,
+                },
+            },
+        },
+        show_parent = widget,
     }
     local close_button = FrameContainer:new{
         bordersize = Size.border.button,
         radius = Size.radius.button,
-        padding = Screen:scaleBySize(6),
-        padding_left = Screen:scaleBySize(12),
-        padding_right = Screen:scaleBySize(12),
+        padding = Screen:scaleBySize(2),
         background = Blitbuffer.COLOR_WHITE,
-        close_button_text,
+        close_button_table,
     }
     local close_button_row = RightContainer:new{
         dimen = { w = screen_width - Screen:scaleBySize(10), h = close_button:getSize().h + Screen:scaleBySize(10) },
@@ -520,89 +594,44 @@ function FileSyncManager:showQRCode()
         overlap,
     }
 
-    -- Build the InputContainer for handling taps
-    local widget = InputContainer:new{
-        width = screen_width,
-        height = screen_height,
-    }
     widget[1] = frame
 
-    -- Store button references for hit testing
-    widget._stop_button = stop_button
-    widget._close_button = close_button
-    widget._manager = self
+    -- Hand both ButtonTables' focus rows to the popup, side by side, so that
+    -- Left/Right moves between "Stop Server" and the close button. (These are
+    -- no-ops on devices without a D-pad, where ButtonTable has no layout.)
+    widget:mergeLayoutInHorizontal(stop_button_table)
+    widget:mergeLayoutInHorizontal(close_button_table)
+    if widget.layout[1] and widget.layout[1][1] then
+        -- Start with "Stop Server" focused (only visibly so on non-touch devices)
+        widget:refocusWidget()
+    end
 
-    widget.ges_events = {
-        Tap = {
+    -- Key handling: on any device with keys, Back leaves the screen through the
+    -- same confirmation the close button shows. Focus movement and activation
+    -- (Up/Down/Left/Right, Press) are registered by FocusManager itself.
+    if Device:hasKeys() then
+        widget.key_events.Close = { { Device.input.group.Back } }
+    end
+
+    -- Touch handling: swallow taps that miss the buttons, so the popup is never
+    -- dismissed by an accidental tap (same as the previous behaviour).
+    if Device:isTouchDevice() then
+        widget.ges_events.TapSwallow = {
             GestureRange:new{
                 ges = "tap",
                 range = Geom:new{ x = 0, y = 0, w = screen_width, h = screen_height },
             },
-        },
-    }
+        }
+    end
 
-    function widget:onTap(_event, ges)
-        if not ges then return true end
-        local x, y = ges.pos.x, ges.pos.y
-
-        -- Check if the tap is on the Stop Server button
-        local btn = self._stop_button
-        if btn.dimen then
-            if x >= btn.dimen.x and x <= btn.dimen.x + btn.dimen.w
-               and y >= btn.dimen.y and y <= btn.dimen.y + btn.dimen.h then
-                -- Stop button tapped: show feedback, then stop and restart
-                self._manager:closeQRScreen()
-                UIManager:show(InfoMessage:new{
-                    text = _("Stopping server..."),
-                    timeout = 2,
-                })
-                -- Schedule the actual stop+restart after a brief moment so the
-                -- InfoMessage renders on the e-ink screen before the restart
-                UIManager:scheduleIn(0.5, function()
-                    self._manager:stop(true)
-                    UIManager:restartKOReader()
-                end)
-                return true
-            end
-        end
-
-        -- Check if the tap is on the X close button
-        local close_btn = self._close_button
-        if close_btn.dimen then
-            if x >= close_btn.dimen.x and x <= close_btn.dimen.x + close_btn.dimen.w
-               and y >= close_btn.dimen.y and y <= close_btn.dimen.y + close_btn.dimen.h then
-                -- X button tapped: ask user what to do
-                local manager = self._manager
-                UIManager:show(ConfirmBox:new{
-                    title = _("File server is running"),
-                    text = _("The server will keep running in the background and prevent the device from sleeping. What would you like to do?"),
-                    ok_text = _("Stop server"),
-                    cancel_text = _("Keep running"),
-                    ok_callback = function()
-                        manager:closeQRScreen()
-                        UIManager:show(InfoMessage:new{
-                            text = _("Stopping server..."),
-                            timeout = 2,
-                        })
-                        UIManager:scheduleIn(0.5, function()
-                            manager:stop(true)
-                            UIManager:restartKOReader()
-                        end)
-                    end,
-                    cancel_callback = function()
-                        manager:closeQRScreen()
-                    end,
-                })
-                return true
-            end
-        end
-
-        -- Tap anywhere else: do nothing (no dismiss)
+    --- Taps outside the buttons do nothing, but must not fall through.
+    function widget:onTapSwallow()
         return true
     end
 
+    --- Back key: leave the QR screen, warning that the server keeps running.
     function widget:onClose()
-        -- Only dismiss via X button, not via generic close/back key
+        manager:confirmLeaveQRScreen()
         return true
     end
 

--- a/filesync/filesyncmanager.lua
+++ b/filesync/filesyncmanager.lua
@@ -4,6 +4,7 @@
 ---
 --- Key dependencies: device (KOReader), UIManager (KOReader), filesync/httpserver
 
+local BD = require("ui/bidi")
 local Blitbuffer = require("ffi/blitbuffer")
 local ButtonTable = require("ui/widget/buttontable")
 local CenterContainer = require("ui/widget/container/centercontainer")
@@ -604,6 +605,26 @@ function FileSyncManager:showQRCode()
     if widget.layout[1] and widget.layout[1][1] then
         -- Start with "Stop Server" focused (only visibly so on non-touch devices)
         widget:refocusWidget()
+    end
+
+    -- FocusManager only steps vertically between rows of its layout, and our
+    -- two buttons live side by side in a single row, so Up/Down would move
+    -- nowhere. Map them onto the equivalent horizontal move, so the buttons can
+    -- be cycled with either axis (Left is not even available on few-keys
+    -- devices, where Up/Down is the only way across).
+    local focusMove = widget.onFocusMove
+    function widget:onFocusMove(args)
+        local dx, dy = unpack(args)
+        if dx == 0 and dy ~= 0 and #self.layout == 1 then
+            dx = dy > 0 and 1 or -1
+            if BD.mirroredUILayout() then
+                -- onFocusMove flips dx again in RTL; undo it here so that Down
+                -- always moves to the next button as laid out on screen.
+                dx = -dx
+            end
+            args = { dx, 0 }
+        end
+        return focusMove(self, args)
     end
 
     -- Key handling: on any device with keys, Back leaves the screen through the


### PR DESCRIPTION
## Problem

On keypad-only e-readers such as the Kindle 4 non-touch (K4B), starting the FileSync server strands the user in the full-screen QR popup. Neither "Stop Server" nor the "×" button can be reached, and Back does nothing, the only escape is to sleep and wake the device, leaving the server running.

Root cause, all three confirmed in `filesync/filesyncmanager.lua`:

- `showQRCode()` built the popup as a raw `InputContainer` driven by a single full-screen `Tap` gesture with manual coordinate hit-testing against `stop_button.dimen` / `close_button.dimen`.
- The "buttons" were plain `FrameContainer`s, not focusable widgets — nothing for a D-pad to move between, and no focus indicator.
- `onClose()` unconditionally returned `true`, deliberately swallowing Back.

## Changes

**`filesync/filesyncmanager.lua`**

- The popup is now a `FocusManager` with real `ButtonTable` buttons. D-pad focus movement, centre-key activation and the focus outline come from the framework instead of hand-rolled maths. The buttons keep their previous bordered look and screen positions.
- `mergeLayoutInHorizontal` puts both buttons in one focus row, so Left/Right (and Right alone, which matters on `hasFewKeys` devices) cycles between them. `refocusWidget()` starts on "Stop Server"; the inversion is drawn only on non-touch devices via the default `FOCUS_ONLY_ON_NT` flags.
- Keys are registered on any device with keys (`Device:hasKeys()` → Back = Close); the tap-swallow gesture is registered only under `Device:isTouchDevice()`. One code path, no touch/non-touch fork.
- `onClose()` no longer swallows Back — it raises the same "File server is running" `ConfirmBox` the close button shows, so the user is still told the server keeps running.
- Stop and confirm-leave logic extracted to `stopFromQRScreen()` / `confirmLeaveQRScreen()`, so the key and touch paths run byte-identical logic. All the old hit-testing code is deleted.
- The instructions text gains a key hint only on devices that have keys.

**`README.md`** notes that the on-device screens are operable with the D-pad and physical keys.

`main.lua` is unchanged; the audit found nothing broken there.

## Non-touch audit

Every other UI path was inspected and cleared, because each uses a stock KOReader widget with no customization that bypasses key input:

- **Port entry dialog** — stock `InputDialog` extends `FocusManager`, registers Back under `hasKeys()`, merges its `ButtonTable` layout. The `onShowKeyboard()` call is safe: `VirtualKeyboard` is itself a `FocusManager`.
- **All `ConfirmBox`es** (low battery, "file server is running", updater's new-version and restart prompts) — stock: Back under `hasKeys()`, `ButtonTable` buttons, tap-to-dismiss only under `isTouchDevice()`.
- **All `InfoMessage`s** across `filesyncmanager.lua`, `main.lua` and `updater.lua` — stock `InfoMessage` registers `AnyKeyPressed` under `hasKeys()`; every one also carries a timeout.
- **WiFi prompt** — deferred to `NetworkMgr`, i.e. KOReader's own prompt.
- **Main menu, including "Show QR code"** — plain `sub_item_table` entries rendered by the stock `Menu`.
- **`httpserver.lua` / `fileops.lua` / `json.lua` / `mobi.lua` / `utils.lua`** — no widget, gesture or key code at all.

## Hardware verification

`busted` passes (195/195) and `luac -p` is clean on both modified files, but the unit tests do not load the UI layer and none of this can be verified end-to-end without physical non-touch hardware. A K4B owner should confirm on this branch:

1. The QR screen shows "Stop Server" highlighted, plus the arrow-key hint line.
2. Left/Right moves the highlight between "Stop Server" and "×".
3. The centre key on "Stop Server" shows "Stopping server…", stops the server and restarts KOReader.
4. The centre key on "×" raises the "File server is running" dialog, whose own buttons are navigable.
5. Back on the QR screen raises that same dialog instead of doing nothing.
6. No page-turn or Home key produces a dead-end state, and the QR code is still scannable.
7. The "Server port" dialog is navigable with Save/Cancel reachable.

Closes #31