### PR TITLE
feat: publish file server toggle as a Simple UI quick action

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ All settings are restored to their previous values when the server is stopped. I
 - Tap **Stop file server** from the plugin menu, or
 - The server stops automatically when you exit KOReader
 
+### Simple UI Quick Action
+
+If you also use the [Simple UI](https://github.com/doctorhetfield-cmd/simpleui.koplugin) plugin, FileSync publishes the server toggle as a quick action so it can be added to Simple UI's bottom bar or homescreen. Pick **File server** from Simple UI's quick action list — its label follows the server state (**Start file server** / **Stop file server**).
+
+The toggle is also available as a gesture action: **Settings → Taps and gestures → Gesture manager → General → Toggle FileSync server**.
+
 ### Changing the Port
 
 1. Open the plugin menu
@@ -229,10 +235,10 @@ luarocks install busted
 busted
 ```
 
-This runs 177+ tests across 5 spec files. You should see output like:
+This runs 208+ tests across 6 spec files. You should see output like:
 
 ```
-177 successes / 0 failures / 0 errors / 0 pending : 0.04 seconds
+208 successes / 0 failures / 0 errors / 0 pending : 0.04 seconds
 ```
 
 **Run a specific spec file:**

--- a/filesync/i18n/ar.po
+++ b/filesync/i18n/ar.po
@@ -17,6 +17,9 @@ msgstr "يُشغّل خادم HTTP محلي ويعرض رمز QR. امسحه ب�
 msgid "Stop file server"
 msgstr "إيقاف خادم الملفات"
 
+msgid "File server"
+msgstr "خادم الملفات"
+
 msgid "Start file server"
 msgstr "تشغيل خادم الملفات"
 

--- a/filesync/i18n/de.po
+++ b/filesync/i18n/de.po
@@ -17,6 +17,9 @@ msgstr "Startet einen lokalen HTTP-Webserver und zeigt einen QR-Code an. Scannen
 msgid "Stop file server"
 msgstr "Dateiserver stoppen"
 
+msgid "File server"
+msgstr "Dateiserver"
+
 msgid "Start file server"
 msgstr "Dateiserver starten"
 

--- a/filesync/i18n/en.po
+++ b/filesync/i18n/en.po
@@ -18,6 +18,9 @@ msgstr ""
 msgid "Stop file server"
 msgstr ""
 
+msgid "File server"
+msgstr ""
+
 msgid "Start file server"
 msgstr ""
 

--- a/filesync/i18n/es.po
+++ b/filesync/i18n/es.po
@@ -17,6 +17,9 @@ msgstr "Inicia un servidor web HTTP local y muestra un código QR. Escanéalo co
 msgid "Stop file server"
 msgstr "Detener servidor de archivos"
 
+msgid "File server"
+msgstr "Servidor de archivos"
+
 msgid "Start file server"
 msgstr "Iniciar servidor de archivos"
 

--- a/filesync/i18n/fr.po
+++ b/filesync/i18n/fr.po
@@ -17,6 +17,9 @@ msgstr "Lance un serveur web HTTP local et affiche un code QR. Scannez-le avec v
 msgid "Stop file server"
 msgstr "Arrêter le serveur de fichiers"
 
+msgid "File server"
+msgstr "Serveur de fichiers"
+
 msgid "Start file server"
 msgstr "Démarrer le serveur de fichiers"
 

--- a/filesync/i18n/ja.po
+++ b/filesync/i18n/ja.po
@@ -17,6 +17,9 @@ msgstr "ローカルHTTPウェブサーバーを起動し、QRコードを表示
 msgid "Stop file server"
 msgstr "ファイルサーバーを停止"
 
+msgid "File server"
+msgstr "ファイルサーバー"
+
 msgid "Start file server"
 msgstr "ファイルサーバーを起動"
 

--- a/filesync/i18n/ko.po
+++ b/filesync/i18n/ko.po
@@ -17,6 +17,9 @@ msgstr "로컬 HTTP 웹 서버를 실행하고 QR 코드를 표시합니다. 휴
 msgid "Stop file server"
 msgstr "파일 서버 중지"
 
+msgid "File server"
+msgstr "파일 서버"
+
 msgid "Start file server"
 msgstr "파일 서버 시작"
 

--- a/filesync/i18n/pt_BR.po
+++ b/filesync/i18n/pt_BR.po
@@ -17,6 +17,9 @@ msgstr "Inicie um servidor web HTTP local e exiba um código QR. Escaneie com se
 msgid "Stop file server"
 msgstr "Parar servidor de arquivos"
 
+msgid "File server"
+msgstr "Servidor de arquivos"
+
 msgid "Start file server"
 msgstr "Iniciar servidor de arquivos"
 

--- a/filesync/i18n/ru.po
+++ b/filesync/i18n/ru.po
@@ -17,6 +17,9 @@ msgstr "Запускает локальный HTTP веб-сервер и ото
 msgid "Stop file server"
 msgstr "Остановить файловый сервер"
 
+msgid "File server"
+msgstr "Файловый сервер"
+
 msgid "Start file server"
 msgstr "Запустить файловый сервер"
 

--- a/filesync/i18n/zh_CN.po
+++ b/filesync/i18n/zh_CN.po
@@ -17,6 +17,9 @@ msgstr "启动本地 HTTP Web 服务器并显示二维码。使用手机扫描�
 msgid "Stop file server"
 msgstr "停止文件服务器"
 
+msgid "File server"
+msgstr "文件服务器"
+
 msgid "Start file server"
 msgstr "启动文件服务器"
 

--- a/filesync/simpleui.lua
+++ b/filesync/simpleui.lua
@@ -1,0 +1,119 @@
+--- Simple UI Quick Action integration.
+--- Publishes "toggle the file server" as a Quick Action for the Simple UI
+--- plugin (https://github.com/doctorhetfield-cmd/simpleui.koplugin) so it can
+--- be placed on its bottom bar / homescreen.
+---
+--- Simple UI exposes an external registration API in
+--- features/sui_quickactions.lua (QA.register(descriptor)). The registry lives
+--- in memory only, so registration must happen on every KOReader start.
+---
+--- Plugins are loaded alphabetically, so "filesync" is initialised before
+--- "simpleui" and the Quick Actions module usually is not available yet on our
+--- first attempt. We therefore retry a few times before giving up. When Simple
+--- UI is not installed at all, every attempt is a silent no-op.
+
+local UIManager = require("ui/uimanager")
+local Event = require("ui/event")
+local logger = require("logger")
+local Utils = require("filesync/utils")
+local ok_i18n, plugin_gettext = pcall(require, "filesync/filesync_i18n")
+local _ = ok_i18n and plugin_gettext or require("gettext")
+
+local QA_MODULE = "features/sui_quickactions"
+local CONFIG_MODULE = "infra/sui_config"
+
+local SimpleUI = {
+    QA_ID = "filesync_toggle_server",
+    RETRY_INTERVAL = 2, -- seconds between attempts while Simple UI loads
+    MAX_ATTEMPTS = 5,
+
+    _registered = false,
+    _attempts = 0,
+    _retry_scheduled = false,
+}
+
+--- Resolve Simple UI's Quick Actions module, or nil when unavailable.
+--- Prefers the already-loaded module: `require` only resolves once Simple UI
+--- itself has been loaded and its plugin directory added to package.path.
+local function getQuickActions()
+    local QA = package.loaded[QA_MODULE]
+    if not QA then
+        local ok, mod = pcall(require, QA_MODULE)
+        QA = ok and mod or nil
+    end
+    if type(QA) == "table" and type(QA.register) == "function" then
+        return QA
+    end
+    return nil
+end
+
+--- Build the Quick Action descriptor handed to Simple UI.
+function SimpleUI:getDescriptor()
+    return {
+        id = self.QA_ID,
+        label = _("File server"),
+        icon = Utils.getPluginDir() .. "/filesync/icon.png",
+        -- Called on every render: reflect the current server state.
+        get_label = function()
+            local ok, running = pcall(function()
+                return require("filesync/filesyncmanager"):isRunning()
+            end)
+            if ok and running then
+                return _("Stop file server")
+            end
+            return _("Start file server")
+        end,
+        -- Runs without leaving the Simple UI screen, and opens widgets
+        -- (battery warning, QR code) that outlive the execute() call.
+        is_in_place = true,
+        is_async_in_place = true,
+        execute = function()
+            -- Reuse the Dispatcher event so the toggle logic stays in main.lua.
+            UIManager:broadcastEvent(Event:new("ToggleFileSyncServer"))
+        end,
+    }
+end
+
+function SimpleUI:_scheduleRetry()
+    if self._retry_scheduled or self._attempts >= self.MAX_ATTEMPTS then return end
+    self._retry_scheduled = true
+    UIManager:scheduleIn(self.RETRY_INTERVAL, function()
+        self._retry_scheduled = false
+        self:register()
+    end)
+end
+
+--- Register the Quick Action with Simple UI.
+--- Idempotent and safe to call when Simple UI is not installed.
+--- @return boolean: true when the action is registered
+function SimpleUI:register()
+    if self._registered then return true end
+
+    self._attempts = self._attempts + 1
+    local QA = getQuickActions()
+    if not QA then
+        self:_scheduleRetry()
+        return false
+    end
+
+    local ok, err = pcall(function()
+        QA.register(self:getDescriptor())
+        -- Simple UI memoizes the validated bottom bar tab list on first use and
+        -- drops ids it does not know yet, so invalidate that cache after a late
+        -- registration.
+        local ok_config, Config = pcall(require, CONFIG_MODULE)
+        if ok_config and type(Config) == "table" and Config.invalidateTabsCache then
+            Config.invalidateTabsCache()
+        end
+    end)
+    if not ok then
+        logger.warn("filesync: Simple UI quick action registration failed: " .. tostring(err))
+        return false
+    end
+
+    self._registered = true
+    logger.dbg("filesync: registered Simple UI quick action")
+    return true
+end
+
+return SimpleUI

--- a/main.lua
+++ b/main.lua
@@ -23,6 +23,9 @@ end
 
 function FileSync:init()
     self:onDispatcherRegisterActions()
+    -- Publish the server toggle as a Simple UI quick action (no-op when the
+    -- Simple UI plugin is not installed).
+    require("filesync/simpleui"):register()
     self.ui.menu:registerToMainMenu(self)
 end
 

--- a/spec/simpleui_spec.lua
+++ b/spec/simpleui_spec.lua
@@ -1,0 +1,149 @@
+--- Tests for the Simple UI quick action integration.
+
+-- Stub the KOReader modules simpleui.lua requires at load time.
+local scheduled = {}
+package.loaded["ui/uimanager"] = {
+    scheduleIn = function(_, seconds, callback)
+        scheduled[#scheduled + 1] = { seconds = seconds, callback = callback }
+    end,
+    broadcastEvent = function(_, event)
+        scheduled.last_event = event
+    end,
+}
+package.loaded["ui/event"] = {
+    new = function(_, name) return { name = name } end,
+}
+package.loaded["gettext"] = function(s) return s end
+package.loaded["filesync/utils"] = {
+    getPluginDir = function() return "/tmp/fake_plugin" end,
+}
+
+local SimpleUI = require("filesync/simpleui")
+
+--- Reset the module's registration state between tests.
+local function reset()
+    SimpleUI._registered = false
+    SimpleUI._attempts = 0
+    SimpleUI._retry_scheduled = false
+    scheduled = {}
+    package.loaded["features/sui_quickactions"] = nil
+    package.loaded["infra/sui_config"] = nil
+end
+
+--- Install a fake Simple UI Quick Actions module and return it.
+local function fakeQuickActions()
+    local QA = { registered = {} }
+    QA.register = function(descriptor)
+        QA.registered[#QA.registered + 1] = descriptor
+    end
+    package.loaded["features/sui_quickactions"] = QA
+    return QA
+end
+
+describe("filesync.simpleui", function()
+
+    before_each(reset)
+    after_each(reset)
+
+    describe("getDescriptor", function()
+
+        it("uses a stable id and the plugin icon", function()
+            local d = SimpleUI:getDescriptor()
+            assert.are.equal("filesync_toggle_server", d.id)
+            assert.are.equal("/tmp/fake_plugin/filesync/icon.png", d.icon)
+        end)
+
+        it("runs in place asynchronously", function()
+            local d = SimpleUI:getDescriptor()
+            assert.is_true(d.is_in_place)
+            assert.is_true(d.is_async_in_place)
+        end)
+
+        it("labels the action by the server state", function()
+            local running = false
+            package.loaded["filesync/filesyncmanager"] = {
+                isRunning = function() return running end,
+            }
+            local d = SimpleUI:getDescriptor()
+            assert.are.equal("Start file server", d.get_label())
+            running = true
+            assert.are.equal("Stop file server", d.get_label())
+            package.loaded["filesync/filesyncmanager"] = nil
+        end)
+
+        it("falls back to the start label when the manager cannot be loaded", function()
+            package.loaded["filesync/filesyncmanager"] = nil
+            local d = SimpleUI:getDescriptor()
+            assert.are.equal("Start file server", d.get_label())
+        end)
+
+        it("broadcasts the toggle event on execute", function()
+            SimpleUI:getDescriptor().execute()
+            assert.are.equal("ToggleFileSyncServer", scheduled.last_event.name)
+        end)
+    end)
+
+    describe("register", function()
+
+        it("registers the descriptor when Simple UI is available", function()
+            local QA = fakeQuickActions()
+            assert.is_true(SimpleUI:register())
+            assert.are.equal(1, #QA.registered)
+            assert.are.equal("filesync_toggle_server", QA.registered[1].id)
+        end)
+
+        it("invalidates the Simple UI tabs cache", function()
+            fakeQuickActions()
+            local invalidated = false
+            package.loaded["infra/sui_config"] = {
+                invalidateTabsCache = function() invalidated = true end,
+            }
+            SimpleUI:register()
+            assert.is_true(invalidated)
+        end)
+
+        it("does not register twice", function()
+            local QA = fakeQuickActions()
+            SimpleUI:register()
+            SimpleUI:register()
+            assert.are.equal(1, #QA.registered)
+        end)
+
+        it("schedules a retry when Simple UI is not loaded yet", function()
+            assert.is_false(SimpleUI:register())
+            assert.are.equal(1, #scheduled)
+            assert.are.equal(SimpleUI.RETRY_INTERVAL, scheduled[1].seconds)
+        end)
+
+        it("registers on a retry once Simple UI has loaded", function()
+            assert.is_false(SimpleUI:register())
+            local QA = fakeQuickActions()
+            scheduled[1].callback()
+            assert.is_true(SimpleUI._registered)
+            assert.are.equal(1, #QA.registered)
+        end)
+
+        it("keeps only one pending retry at a time", function()
+            SimpleUI:register()
+            SimpleUI:register()
+            assert.are.equal(1, #scheduled)
+        end)
+
+        it("gives up after MAX_ATTEMPTS", function()
+            for _ = 1, SimpleUI.MAX_ATTEMPTS + 2 do
+                SimpleUI._retry_scheduled = false
+                SimpleUI:register()
+            end
+            assert.are.equal(SimpleUI.MAX_ATTEMPTS - 1, #scheduled)
+            assert.is_false(SimpleUI._registered)
+        end)
+
+        it("survives a Simple UI module that throws", function()
+            package.loaded["features/sui_quickactions"] = {
+                register = function() error("boom") end,
+            }
+            assert.is_false(SimpleUI:register())
+            assert.is_false(SimpleUI._registered)
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary

[Simple UI](https://github.com/doctorhetfield-cmd/simpleui.koplugin) lets external plugins add Quick Actions through `QA.register(descriptor)` in `features/sui_quickactions.lua`. FileSync now registers a **File server** action there, so the server toggle can be placed on Simple UI's bottom bar or homescreen.

## Details

- New `filesync/simpleui.lua` builds and registers the descriptor:
  - dynamic `get_label` — *Start file server* / *Stop file server*, following the live server state
  - the plugin's own `filesync/icon.png` as the icon
  - `is_in_place` + `is_async_in_place` — the action runs without leaving the Simple UI screen and opens widgets (battery warning, QR code) that outlive the call
  - `execute` broadcasts the existing `ToggleFileSyncServer` event, so the toggle logic stays in `main.lua` and is shared with the Dispatcher/gesture action
- Registration runs from `FileSync:init()`. Simple UI's registry is in-memory only, so it must run on every start. Plugins load alphabetically, so Simple UI usually is not loaded yet on the first attempt — the module retries every 2 s, up to 5 attempts, then gives up. With Simple UI not installed, every attempt is a silent no-op.
- After a late registration the module invalidates Simple UI's memoized tab list (`Config.invalidateTabsCache`), which would otherwise drop the not-yet-known action id for the rest of the session.
- Adds the `File server` string to all 10 `.po` files, a README section, and 13 unit tests (suite now 208).