### PR TITLE
feat: show hidden files and folders when safe mode is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ Safe mode is **enabled by default** and limits the web interface to only show fi
 
 - Only **ebooks** (EPUB, PDF, MOBI, AZW3, FB2, DJVU, CBZ, etc.), **documents** (TXT, DOC, RTF, HTML, etc.), and **images** (JPG, PNG, GIF, WebP) are shown
 - System files, configuration files, and other non-book files are hidden
+- Hidden files and folders (names starting with `.`) are hidden
 - KOReader metadata directories (`.sdr` folders) are hidden and automatically cleaned up when deleting a book
 
-To toggle safe mode, open the plugin menu and tap **Safe mode**. Disabling it will show all files on the device.
+To toggle safe mode, open the plugin menu and tap **Safe mode**. Disabling it will show every file on the device, including hidden files and folders, which are dimmed in the listing to set them apart.
 
 ## Troubleshooting
 

--- a/filesync/fileops.lua
+++ b/filesync/fileops.lua
@@ -202,7 +202,8 @@ end
 --- @param sort_by string: sort field ("name", "size", "date", "type")
 --- @param sort_order string: "asc" or "desc"
 --- @param filter string: case-insensitive substring filter for filenames
---- @param safe_mode boolean: when true, only show whitelisted file types
+--- @param safe_mode boolean: when true, only show whitelisted file types and
+---   hide dotfiles; when false, list every entry including hidden ones
 --- @return table|nil: {path, entries, breadcrumbs, count} on success
 --- @return string|nil: error message on failure
 function FileOps:listDirectory(rel_path, sort_by, sort_order, filter, safe_mode)
@@ -220,8 +221,8 @@ function FileOps:listDirectory(rel_path, sort_by, sort_order, filter, safe_mode)
     local ok, iter_err = pcall(function()
         for name in lfs.dir(full_path) do
             if name ~= "." and name ~= ".." then
-                -- Skip hidden files starting with .
-                if name:sub(1, 1) ~= "." then
+                -- Hidden entries are listed only when safe mode is off
+                if not (safe_mode and name:sub(1, 1) == ".") then
                     -- Apply filter if present
                     local include = true
                     if filter and filter ~= "" then

--- a/main.lua
+++ b/main.lua
@@ -58,6 +58,9 @@ function FileSync:addToMainMenu(menu_items)
             },
             {
                 text = _("Safe mode"),
+                help_text = _([[When enabled, the web interface only lists document and image formats KOReader can open, and hides sidecar metadata folders and hidden files.
+
+Disable it to browse every file on the device, including hidden files and folders.]]),
                 checked_func = function()
                     local FileSyncManager = require("filesync/filesyncmanager")
                     return FileSyncManager:getSafeMode()

--- a/spec/fileops_spec.lua
+++ b/spec/fileops_spec.lua
@@ -1,9 +1,52 @@
 -- Stub lfs before requiring fileops, since fileops tries to load it at require-time.
--- We only need a minimal stub; the pure-logic helpers we test don't use lfs.
-package.loaded["lfs"] = {
+-- Most of the helpers we test are pure logic and never touch it; listDirectory does,
+-- so the stub is programmable via mountTree() below. fileops keeps a reference to
+-- this exact table, so replacing its fields in place is enough to steer it.
+local lfs_stub = {
     attributes = function() return nil end,
     dir = function() return function() return nil end end,
 }
+package.loaded["lfs"] = lfs_stub
+
+--- Point the lfs stub at a virtual filesystem.
+--- @param tree table: map of absolute path -> {mode = "directory"|"file", size, modification}
+local function mountTree(tree)
+    lfs_stub.attributes = function(path)
+        return tree[path]
+    end
+    lfs_stub.dir = function(path)
+        local names = {".", ".."}
+        local prefix = path .. "/"
+        for entry_path, _ in pairs(tree) do
+            local name = entry_path:sub(#prefix + 1)
+            -- Direct children only: starts with the prefix, no further slash
+            if entry_path:sub(1, #prefix) == prefix and name ~= "" and not name:find("/") then
+                table.insert(names, name)
+            end
+        end
+        table.sort(names)
+        local i = 0
+        return function()
+            i = i + 1
+            return names[i]
+        end
+    end
+end
+
+--- Restore the inert default stub so unrelated tests are unaffected.
+local function unmountTree()
+    lfs_stub.attributes = function() return nil end
+    lfs_stub.dir = function() return function() return nil end end
+end
+
+--- Collect entry names from a listDirectory result into a lookup table.
+local function nameSet(result)
+    local set = {}
+    for _, entry in ipairs(result.entries) do
+        set[entry.name] = true
+    end
+    return set
+end
 
 local FileOps = require("filesync/fileops")
 
@@ -344,6 +387,86 @@ describe("filesync.fileops", function()
 
         it("returns false for nil", function()
             assert.is_false(FileOps:isExtensionSafe(nil))
+        end)
+    end)
+    describe("listDirectory hidden entries", function()
+
+        -- A root holding every interesting category: hidden dir, hidden dotfile
+        -- with a non-whitelisted name, hidden dotfile that *is* whitelisted,
+        -- a sidecar .sdr directory, and ordinary safe/unsafe files.
+        local TREE = {
+            ["/mnt/us"]              = {mode = "directory", size = 4096, modification = 100},
+            ["/mnt/us/.config"]      = {mode = "directory", size = 4096, modification = 100},
+            ["/mnt/us/.gitignore"]   = {mode = "file",      size = 12,   modification = 100},
+            ["/mnt/us/.hidden.epub"] = {mode = "file",      size = 34,   modification = 100},
+            ["/mnt/us/Books"]        = {mode = "directory", size = 4096, modification = 100},
+            ["/mnt/us/book.epub"]    = {mode = "file",      size = 56,   modification = 100},
+            ["/mnt/us/book.sdr"]     = {mode = "directory", size = 4096, modification = 100},
+            ["/mnt/us/notes.txt"]    = {mode = "file",      size = 78,   modification = 100},
+            ["/mnt/us/script.sh"]    = {mode = "file",      size = 90,   modification = 100},
+        }
+
+        before_each(function()
+            FileOps:setRootDir("/mnt/us")
+            mountTree(TREE)
+        end)
+
+        after_each(function()
+            unmountTree()
+        end)
+
+        it("hides dotfiles and dot-directories in safe mode", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", true)
+            local names = nameSet(result)
+            assert.is_nil(names[".config"])
+            assert.is_nil(names[".gitignore"])
+        end)
+
+        it("hides dotfiles in safe mode even with a whitelisted extension", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", true)
+            assert.is_nil(nameSet(result)[".hidden.epub"])
+        end)
+
+        it("lists dotfiles and dot-directories when safe mode is off", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", false)
+            local names = nameSet(result)
+            assert.is_true(names[".config"])
+            assert.is_true(names[".gitignore"])
+            assert.is_true(names[".hidden.epub"])
+        end)
+
+        it("still applies the extension whitelist in safe mode", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", true)
+            local names = nameSet(result)
+            assert.is_true(names["book.epub"])
+            assert.is_true(names["notes.txt"])
+            assert.is_nil(names["script.sh"])
+        end)
+
+        it("still hides .sdr directories in safe mode", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", true)
+            assert.is_nil(nameSet(result)["book.sdr"])
+        end)
+
+        it("lists .sdr directories and every extension when safe mode is off", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "", false)
+            local names = nameSet(result)
+            assert.is_true(names["book.sdr"])
+            assert.is_true(names["script.sh"])
+        end)
+
+        it("keeps the name filter applied to hidden entries", function()
+            local result = FileOps:listDirectory("/", "name", "asc", "git", false)
+            local names = nameSet(result)
+            assert.is_true(names[".gitignore"])
+            assert.is_nil(names["book.epub"])
+        end)
+
+        it("reports a count matching the visible entries", function()
+            local safe = FileOps:listDirectory("/", "name", "asc", "", true)
+            local unsafe = FileOps:listDirectory("/", "name", "asc", "", false)
+            assert.are.equal(3, safe.count)
+            assert.are.equal(8, unsafe.count)
         end)
     end)
 end)


### PR DESCRIPTION
Closes #32
Supersedes #33

## Problem

`listDirectory` skipped every dotfile unconditionally, before safe mode was consulted:

```lua
if name ~= "." and name ~= ".." then
    -- Skip hidden files starting with .
    if name:sub(1, 1) ~= "." then
```

So hidden files and folders were unreachable from the web interface in either mode. Worth noting for the discussion on #32: safe mode was not the cause — this filter runs first and ignores it entirely.

## Approach

Gate the dotfile filter on `safe_mode` rather than adding a separate toggle.

Safe mode already draws exactly this line. With it on you get a curated, book-only view; with it off you already see every file extension *and* the `.sdr` sidecar directories. Dotfiles were the one category that stayed hidden in both, which is the inconsistency the issue reports. Folding them in makes "safe mode off" mean one coherent thing: show the actual filesystem.

This also avoids a trap in the standalone-toggle approach. Most dotfiles a user would want to see (`.gitignore`, `.env`, extensionless configs) are not on the safe-mode whitelist, so with safe mode on — the default — a dedicated toggle would reveal almost nothing and look broken.

## Changes

- `filesync/fileops.lua` — the dotfile skip becomes `if not (safe_mode and name:sub(1, 1) == ".")`, plus an updated doc comment on the parameter
- `main.lua` — a `help_text` on the **Safe mode** menu entry, which previously had no explanation of what it does
- `README.md` — documents hidden-file behaviour in the Safe Mode section
- `spec/fileops_spec.lua` — `listDirectory` coverage, which did not exist before

No frontend changes and no `build.sh` rerun: `src/js/file-list.js:115` already tags dotfile entries with `is-hidden`, and the dimmed styling in `file-list.css` plus its theme variables already exist. That scaffolding was dead only because dotfiles never reached the browser — it now activates on its own.

## Notes

- **Default behaviour is unchanged.** Safe mode defaults to `true`, so nothing differs until a user opts out.
- The 8 new specs were verified to fail against the previous behaviour, not just pass against the new one. Full suite: 216 passing.
- Pre-existing and untouched: the `is_empty` check and `_countFilesRecursive` count dotfiles regardless of safe mode, so with safe mode on a folder holding only dotfiles renders as non-empty but lists nothing. Happy to fix separately if you want it.
- Translated READMEs are not updated — left for whoever maintains them.