### PR TITLE
feat: support KOReader's delete plugin settings option

### DIFF
--- a/filesync/filesyncmanager.lua
+++ b/filesync/filesyncmanager.lua
@@ -92,6 +92,21 @@ function FileSyncManager:setSafeMode(enabled)
     G_reader_settings:flush()
 end
 
+--- Settings this plugin persists in G_reader_settings. Kept in one place so
+--- deleteSettings() cannot drift from the readers/writers above.
+local SETTINGS_KEYS = { "filesync_port", "filesync_safe_mode" }
+
+--- Remove every setting this plugin owns, restoring first-run defaults.
+--- Called by KOReader's plugin manager through FileSync:deletePluginSettings().
+function FileSyncManager:deleteSettings()
+    for _i, key in ipairs(SETTINGS_KEYS) do
+        G_reader_settings:delSetting(key)
+    end
+    G_reader_settings:flush()
+    -- Drop the cached port so a still-loaded instance re-reads the default.
+    self._port = nil
+end
+
 function FileSyncManager:configurePort()
     local InputDialog = require("ui/widget/inputdialog")
     local port_dialog

--- a/main.lua
+++ b/main.lua
@@ -149,6 +149,32 @@ function FileSync:onLeaveStandby()
     self:onResume()
 end
 
+--- Called by KOReader's plugin manager (v2026.07+) when the user picks
+--- "Delete plugin settings". Its presence is what makes those menu entries
+--- appear: settings live as flat keys in G_reader_settings, so neither
+--- settings_file nor settings_key applies here.
+function FileSync:deletePluginSettings()
+    local FileSyncManager = require("filesync/filesyncmanager")
+    FileSyncManager:deleteSettings()
+end
+
+--- Called by KOReader's plugin manager before the plugin directory is removed.
+--- Shuts the HTTP server down (and drops the Kindle firewall rules) so nothing
+--- outlives the deletion; the caller restarts KOReader afterwards.
+function FileSync:stopPlugin(force)
+    local FileSyncManager = require("filesync/filesyncmanager")
+    if not FileSyncManager:isRunning() then
+        return true
+    end
+    local ok, err = pcall(function()
+        FileSyncManager:stop(true) -- silent: no restart, the caller handles it
+    end)
+    if not ok and force then
+        return true
+    end
+    return ok, err
+end
+
 function FileSync:onExit()
     local FileSyncManager = require("filesync/filesyncmanager")
     if FileSyncManager:isRunning() then


### PR DESCRIPTION
Closes #25

KOReader added plugin deletion in [koreader/koreader#15240](https://github.com/koreader/koreader/pull/15240), merged 2026-04-06 and shipped in **v2026.07** — it is no longer nightly-only, as the issue assumed.

The settings-related entries (*Disable plugin and delete settings*, *Delete plugin and settings*) are only shown when the loaded plugin instance exposes one of `deletePluginSettings`, `settings_file` or `settings_key` (`frontend/pluginloader.lua:377`). FileSync stores flat keys in `G_reader_settings`, so it matched none of them and users only got *Delete plugin*.

## Changes

- `FileSync:deletePluginSettings()` — the hook KOReader looks for; delegates to the manager.
- `FileSyncManager:deleteSettings()` — deletes `filesync_port` and `filesync_safe_mode`, flushes, and clears the cached port so a still-loaded instance falls back to defaults. The key list lives in one constant so it cannot drift from the readers/writers above it.
- `FileSync:stopPlugin(force)` — KOReader calls this before restarting; stops the HTTP server and removes the Kindle firewall rules. Uses the silent stop path, since the plugin manager handles the restart itself.

Note that KOReader purges the plugin directory *before* calling `stopPlugin`, so the stop path deliberately avoids loading anything new from disk — every module it touches is already in `package.loaded`.