### PR TITLE
fix: don't quit KOReader when stopping the server on Android

### DIFF
--- a/filesync/filesyncmanager.lua
+++ b/filesync/filesyncmanager.lua
@@ -327,7 +327,7 @@ function FileSyncManager:start(silent)
 end
 
 --- Stop the FileSync server: close QR screen, stop HttpServer, remove firewall rules.
---- @param silent boolean|nil: when true, suppress UI messages and skip KOReader restart
+--- @param silent boolean|nil: when true, suppress UI messages and skip the KOReader restart
 function FileSyncManager:stop(silent)
     if not self._running then
         return
@@ -357,7 +357,7 @@ function FileSyncManager:stop(silent)
             text = _("FileSync server stopped."),
             timeout = 2,
         })
-        UIManager:restartKOReader()
+        Utils.restartKOReader()
     end
 end
 
@@ -426,7 +426,8 @@ function FileSyncManager:closeQRScreen()
     end
 end
 
---- Stop the server from the QR screen: close it, show feedback, then stop and restart.
+--- Stop the server from the QR screen: close it, show feedback, then stop and
+--- restart (or refresh, on devices that cannot restart).
 --- Shared by the "Stop Server" button and the confirmation dialog.
 function FileSyncManager:stopFromQRScreen()
     self:closeQRScreen()
@@ -438,7 +439,7 @@ function FileSyncManager:stopFromQRScreen()
     -- InfoMessage renders on the e-ink screen before the restart
     UIManager:scheduleIn(0.5, function()
         self:stop(true)
-        UIManager:restartKOReader()
+        Utils.restartKOReader()
     end)
 end
 

--- a/filesync/i18n/ar.po
+++ b/filesync/i18n/ar.po
@@ -147,6 +147,9 @@ msgstr "جارٍ تثبيت التحديث..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "تم تحديث FileSync بنجاح!\n\nيرجى إعادة تشغيل KOReader لتطبيق التغييرات."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "تم تحديث FileSync بنجاح!\n\nيرجى إغلاق KOReader وإعادة فتحه لتطبيق التغييرات."
+
 msgid "Restart now"
 msgstr "إعادة التشغيل الآن"
 

--- a/filesync/i18n/de.po
+++ b/filesync/i18n/de.po
@@ -147,6 +147,9 @@ msgstr "Update wird installiert..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSync wurde erfolgreich aktualisiert!\n\nBitte starten Sie KOReader neu, damit die Änderungen wirksam werden."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSync wurde erfolgreich aktualisiert!\n\nBitte schließen Sie KOReader und öffnen Sie es erneut, damit die Änderungen wirksam werden."
+
 msgid "Restart now"
 msgstr "Jetzt neu starten"
 

--- a/filesync/i18n/en.po
+++ b/filesync/i18n/en.po
@@ -148,6 +148,9 @@ msgstr ""
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr ""
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr ""
+
 msgid "Restart now"
 msgstr ""
 

--- a/filesync/i18n/es.po
+++ b/filesync/i18n/es.po
@@ -147,6 +147,9 @@ msgstr "Instalando actualización..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "¡FileSync se ha actualizado correctamente!\n\nReinicia KOReader para que los cambios surtan efecto."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "¡FileSync se ha actualizado correctamente!\n\nCierra y vuelve a abrir KOReader para que los cambios surtan efecto."
+
 msgid "Restart now"
 msgstr "Reiniciar ahora"
 

--- a/filesync/i18n/fr.po
+++ b/filesync/i18n/fr.po
@@ -147,6 +147,9 @@ msgstr "Installation de la mise à jour..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSync a été mis à jour avec succès !\n\nVeuillez redémarrer KOReader pour appliquer les modifications."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSync a été mis à jour avec succès !\n\nVeuillez fermer puis rouvrir KOReader pour appliquer les modifications."
+
 msgid "Restart now"
 msgstr "Redémarrer maintenant"
 

--- a/filesync/i18n/ja.po
+++ b/filesync/i18n/ja.po
@@ -147,6 +147,9 @@ msgstr "更新をインストールしています..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSyncの更新が完了しました！\n\n変更を反映するにはKOReaderを再起動してください。"
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSyncの更新が完了しました！\n\n変更を反映するにはKOReaderを一度終了して開き直してください。"
+
 msgid "Restart now"
 msgstr "今すぐ再起動"
 

--- a/filesync/i18n/ko.po
+++ b/filesync/i18n/ko.po
@@ -147,6 +147,9 @@ msgstr "업데이트를 설치하는 중..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSync가 성공적으로 업데이트되었습니다!\n\n변경 사항을 적용하려면 KOReader를 다시 시작하세요."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSync가 성공적으로 업데이트되었습니다!\n\n변경 사항을 적용하려면 KOReader를 종료한 후 다시 여세요."
+
 msgid "Restart now"
 msgstr "지금 다시 시작"
 

--- a/filesync/i18n/pt_BR.po
+++ b/filesync/i18n/pt_BR.po
@@ -147,6 +147,9 @@ msgstr "Instalando atualização..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "O FileSync foi atualizado com sucesso!\n\nReinicie o KOReader para que as mudanças tenham efeito."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "O FileSync foi atualizado com sucesso!\n\nFeche e abra o KOReader novamente para que as mudanças tenham efeito."
+
 msgid "Restart now"
 msgstr "Reiniciar agora"
 

--- a/filesync/i18n/ru.po
+++ b/filesync/i18n/ru.po
@@ -147,6 +147,9 @@ msgstr "Установка обновления..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSync успешно обновлён!\n\nПерезапустите KOReader, чтобы изменения вступили в силу."
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSync успешно обновлён!\n\nЗакройте и снова откройте KOReader, чтобы изменения вступили в силу."
+
 msgid "Restart now"
 msgstr "Перезапустить сейчас"
 

--- a/filesync/i18n/zh_CN.po
+++ b/filesync/i18n/zh_CN.po
@@ -147,6 +147,9 @@ msgstr "正在安装更新..."
 msgid "FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."
 msgstr "FileSync 更新成功！\n\n请重启 KOReader 以使更改生效。"
 
+msgid "FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."
+msgstr "FileSync 更新成功！\n\n请关闭并重新打开 KOReader 以使更改生效。"
+
 msgid "Restart now"
 msgstr "立即重启"
 

--- a/filesync/updater.lua
+++ b/filesync/updater.lua
@@ -451,16 +451,24 @@ function Updater:_performUpdate(release)
                 return
             end
 
-            -- Success — prompt to restart
-            local ConfirmBox = require("ui/widget/confirmbox")
-            UIManager:show(ConfirmBox:new{
-                text = _("FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."),
-                ok_text = _("Restart now"),
-                cancel_text = _("Later"),
-                ok_callback = function()
-                    UIManager:restartKOReader()
-                end,
-            })
+            -- Success — prompt to restart. Devices that cannot restart
+            -- themselves (Android) only get an informational message, since
+            -- offering "Restart now" there would just quit the app.
+            if Utils.canRestartKOReader() then
+                local ConfirmBox = require("ui/widget/confirmbox")
+                UIManager:show(ConfirmBox:new{
+                    text = _("FileSync has been updated successfully!\n\nPlease restart KOReader for the changes to take effect."),
+                    ok_text = _("Restart now"),
+                    cancel_text = _("Later"),
+                    ok_callback = function()
+                        Utils.restartKOReader()
+                    end,
+                })
+            else
+                UIManager:show(InfoMessage:new{
+                    text = _("FileSync has been updated successfully!\n\nPlease close and reopen KOReader for the changes to take effect."),
+                })
+            end
         end)
     end)
 end

--- a/filesync/utils.lua
+++ b/filesync/utils.lua
@@ -2,6 +2,7 @@
 --- Provides common helpers used across multiple modules:
 ---   - getPluginDir(): returns the absolute path to the plugin root directory
 ---   - shellEscape(s): escapes a string for safe use in shell commands
+---   - restartKOReader(): restarts KOReader only on platforms that support it
 
 local Utils = {}
 
@@ -33,6 +34,32 @@ function Utils.shellEscape(s)
     -- Replace each single quote with: end quote, escaped quote, start quote
     local escaped = s:gsub("'", "'\\''")
     return "'" .. escaped .. "'"
+end
+
+--- Restart KOReader, but only on platforms where a restart actually works.
+--- UIManager:restartKOReader() simply exits with code 85 and relies on the
+--- launcher shell script to relaunch the process.  Android has no such
+--- wrapper (it runs as a NativeActivity), so calling it there just quits the
+--- app -- which is why KOReader gates its own "Restart KOReader" menu entry
+--- on Device:canRestart().  Where a restart is unavailable, force a full
+--- screen refresh instead, which is all the restart was buying us.
+--- @return boolean: true if a restart was requested, false if it was skipped
+function Utils.restartKOReader()
+    local Device = require("device")
+    local UIManager = require("ui/uimanager")
+    if Device:canRestart() then
+        UIManager:restartKOReader()
+        return true
+    end
+    UIManager:setDirty("all", "full")
+    return false
+end
+
+--- Whether KOReader can restart itself on this device.
+--- @return boolean
+function Utils.canRestartKOReader()
+    local Device = require("device")
+    return Device:canRestart() and true or false
 end
 
 return Utils

--- a/main.lua
+++ b/main.lua
@@ -118,7 +118,7 @@ function FileSync:onToggleFileSyncServer()
         })
         UIManager:scheduleIn(0.5, function()
             FileSyncManager:stop(true)
-            UIManager:restartKOReader()
+            require("filesync/utils").restartKOReader()
         end)
     else
         FileSyncManager:checkBatteryAndStart()

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -58,4 +58,59 @@ describe("filesync.utils", function()
             assert.are.equal("'/mnt/us/my books/novel.epub'", Utils.shellEscape("/mnt/us/my books/novel.epub"))
         end)
     end)
+
+    describe("restartKOReader", function()
+
+        local calls
+
+        -- Install minimal `device` / `ui/uimanager` stubs for the duration of
+        -- a test, recording which UIManager method the helper reached for.
+        local function stub_koreader(can_restart)
+            calls = {}
+            package.loaded["device"] = {
+                canRestart = function() return can_restart end,
+            }
+            package.loaded["ui/uimanager"] = {
+                restartKOReader = function() calls[#calls + 1] = "restart" end,
+                setDirty = function(_, widget, refresh)
+                    calls[#calls + 1] = "setDirty:" .. tostring(widget) .. ":" .. tostring(refresh)
+                end,
+            }
+        end
+
+        after_each(function()
+            package.loaded["device"] = nil
+            package.loaded["ui/uimanager"] = nil
+        end)
+
+        it("restarts KOReader when the device supports it", function()
+            stub_koreader(true)
+            assert.is_true(Utils.restartKOReader())
+            assert.are.same({ "restart" }, calls)
+        end)
+
+        it("forces a full refresh instead of restarting on Android", function()
+            stub_koreader(false)
+            assert.is_false(Utils.restartKOReader())
+            assert.are.same({ "setDirty:all:full" }, calls)
+        end)
+    end)
+
+    describe("canRestartKOReader", function()
+
+        after_each(function()
+            package.loaded["device"] = nil
+        end)
+
+        it("reports true when the device can restart", function()
+            package.loaded["device"] = { canRestart = function() return true end }
+            assert.is_true(Utils.canRestartKOReader())
+        end)
+
+        it("reports false when the device cannot restart", function()
+            -- KOReader's Device:canRestart is the `no` helper on Android
+            package.loaded["device"] = { canRestart = function() return false end }
+            assert.is_false(Utils.canRestartKOReader())
+        end)
+    end)
 end)


### PR DESCRIPTION
## Problem

On Android, tapping **Stop file server** quits KOReader entirely.

`UIManager:restartKOReader()` exits the process with code 85 and relies on the launcher **shell script** to relaunch it:

```lua
function UIManager:restartKOReader()
    -- This is just a magic number to indicate the restart request for shell scripts.
    self:quit(85)
end
```

Android has no such wrapper — KOReader runs as a NativeActivity — so `frontend/device/android/device.lua` declares `canRestart = no`, and KOReader hides its own "Restart KOReader" menu entry there. The plugin called it unconditionally, so the app just died. The same applies to macOS/SDL (`canRestart = notOSX`).

The restart was never functionally required: `stop()` already closes the socket, clears caches, unschedules polling, and restores standby / auto-suspend. It was introduced purely "for clean UI state" (114ea0b).

## Fix

New `Utils.restartKOReader()` restarts only where the platform supports it, and otherwise forces a full screen refresh — which is all the restart was buying us:

```lua
if Device:canRestart() then
    UIManager:restartKOReader()
    return true
end
UIManager:setDirty("all", "full")
return false
```

Every stop path now goes through it: the menu action and dispatcher gesture (`main.lua`), the QR screen "Stop Server" button and leave-QR confirm dialog, and the non-silent `stop()` path.

The updater had the same bug — its "Restart now" button also quit the app on Android. It now shows an informational message asking the user to close and reopen KOReader instead, with the new string translated across all ten catalogs.

`busted`: 220 passing, including four new cases covering both branches of the helper.

Closes #34