### PR TITLE
docs: add contributors and funding sections to READMEs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: abrahamnm

--- a/README.ar.md
+++ b/README.ar.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | **العربية** | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 إضافة لتطبيق KOReader تُشغّل خادم ويب محلي على جهاز القراءة الإلكتروني وتعرض رمز QR على الشاشة. امسح الرمز بهاتفك لفتح واجهة ويب أنيقة لإدارة الكتب والملفات لاسلكيًا — بدون كابلات، بدون تطبيقات، فقط متصفحك.
 
 يعمل على أجهزة **Kindle** و**Kobo** التي تشغّل KOReader.
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | فك ترميز عناوين URL، تحليل سلاسل الاستعلام |
 
 عند إضافة ميزات جديدة، يُرجى إضافة اختبارات مقابلة لأي دوال منطقية بحتة.
+
+## المساهمون
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## الدعم
+
+إذا وفّر لك FileSync بعض الوقت، يمكنك دعوتي إلى فنجان قهوة. تقديرك محل ترحيب دائم، ولكنه ليس متوقعًا أبدًا.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## الترخيص
 

--- a/README.de.md
+++ b/README.de.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | **Deutsch** | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 Ein KOReader-Plugin, das einen lokalen Webserver auf Ihrem E-Reader startet und einen QR-Code auf dem Bildschirm anzeigt. Scannen Sie den Code mit Ihrem Smartphone, um eine ansprechende Weboberfläche zur kabellosen Verwaltung Ihrer Bücher und Dateien zu öffnen — keine Kabel, keine Apps, nur Ihr Browser.
 
 Funktioniert auf Geräten mit KOReader (entwickelt für **Kindle** und **Kobo**).
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | URL-Dekodierung, Query-String-Analyse |
 
 Bitte fügen Sie beim Hinzufügen neuer Funktionen entsprechende Tests für reine Logikfunktionen hinzu.
+
+## Mitwirkende
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Unterstützen
+
+Wenn FileSync Ihnen Zeit spart, können Sie mir einen Kaffee spendieren. Immer willkommen, nie erwartet.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | **Español** | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 Un plugin para KOReader que inicia un servidor web local en tu lector electrónico y muestra un código QR en pantalla. Escanea el código con tu teléfono para abrir una interfaz web elegante que te permite gestionar libros y archivos de forma inalámbrica — sin cables, sin apps, solo tu navegador.
 
 Funciona en dispositivos con KOReader instalado (diseñado para **Kindle** y **Kobo**).
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | Decodificación de URLs, análisis de query strings |
 
 Al agregar nuevas funcionalidades, por favor incluye pruebas correspondientes para las funciones de lógica pura.
+
+## Colaboradores
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Apoyar
+
+Si FileSync te ahorra tiempo, puedes invitarme un café. Siempre se agradece, nunca se espera.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | **Français** | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 Un plugin KOReader qui lance un serveur web local sur votre liseuse et affiche un QR code à l'écran. Scannez le code avec votre téléphone pour ouvrir une interface web soignée permettant de gérer vos livres et fichiers sans fil — pas de câbles, pas d'applications, juste votre navigateur.
 
 Fonctionne sur les appareils sous KOReader (conçu pour **Kindle** et **Kobo**).
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | Décodage d'URL, analyse des chaînes de requête |
 
 Lors de l'ajout de nouvelles fonctionnalités, veuillez inclure les tests correspondants pour toute fonction de logique pure.
+
+## Contributeurs
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Soutenir
+
+Si FileSync vous fait gagner du temps, vous pouvez m'offrir un café. Toujours apprécié, jamais attendu.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## Licence
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | **日本語** | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 KOReaderプラグインで、電子書籍リーダー上にローカルウェブサーバーを起動し、画面にQRコードを表示します。スマートフォンでコードをスキャンすると、ブラウザ上で書籍やファイルをワイヤレスで管理できる洗練されたウェブインターフェースが開きます。ケーブルも専用アプリも不要 -- ブラウザだけで利用できます。
 
 KOReaderがインストールされた**Kindle**および**Kobo**デバイスで動作します。
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | URLデコード、クエリ文字列の解析 |
 
 新機能を追加する際は、純粋なロジック関数に対応するテストも追加してください。
+
+## コントリビューター
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## サポート
+
+FileSync が時間の節約になったら、コーヒーを一杯おごっていただけると嬉しいです。もちろん任意です。
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | **한국어**
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 전자책 리더에서 로컬 웹 서버를 실행하고 화면에 QR 코드를 표시하는 KOReader 플러그인입니다. 스마트폰으로 코드를 스캔하면 브라우저에서 깔끔한 웹 인터페이스가 열리며, 케이블이나 별도 앱 없이 책과 파일을 무선으로 관리할 수 있습니다.
 
 KOReader가 설치된 **Kindle** 및 **Kobo** 기기에서 작동합니다.
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | URL 디코딩, 쿼리 문자열 파싱 |
 
 새로운 기능을 추가할 때는 순수 로직 함수에 대한 해당 테스트도 함께 추가해 주세요.
+
+## 기여자
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## 후원
+
+FileSync가 시간을 아껴 주었다면 커피 한 잔 사 주셔도 좋습니다. 언제나 감사하지만, 전혀 부담 갖지 않으셔도 됩니다.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 A KOReader plugin that launches a local web server on your e-reader and displays a QR code on screen. Scan the code with your phone to open a polished web interface for managing books and files wirelessly — no cables, no apps, just your browser.
 
 Works on devices running KOReader (designed for **Kindle** and **Kobo**), including non-touch, keypad-only e-readers — the on-device screens are fully operable with the D-pad and physical keys.
@@ -263,6 +267,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | URL decoding, query string parsing |
 
 When adding new features, please add corresponding tests for any pure-logic functions.
+
+## Contributors
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Support
+
+If FileSync saves you time, you can buy me a coffee. Always appreciated, never expected.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## License
 

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | **Português** | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 Um plugin para KOReader que inicia um servidor web local no seu leitor eletrônico e exibe um código QR na tela. Escaneie o código com seu celular para abrir uma interface web completa que permite gerenciar livros e arquivos sem fio — sem cabos, sem aplicativos, apenas o seu navegador.
 
 Funciona em dispositivos com KOReader instalado (projetado para **Kindle** e **Kobo**).
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | Decodificação de URLs, análise de query strings |
 
 Ao adicionar novas funcionalidades, inclua testes correspondentes para as funções de lógica pura.
+
+## Colaboradores
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Apoie
+
+Se o FileSync te poupa tempo, você pode me pagar um café. Sempre bem-vindo, nunca esperado.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## Licença
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | [中文](README.zh_CN.md) | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | **Русский** | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 Плагин для KOReader, который запускает локальный веб-сервер на вашей электронной книге и отображает QR-код на экране. Отсканируйте код телефоном — и в браузере откроется удобный веб-интерфейс для управления книгами и файлами без проводов. Никаких кабелей, никаких приложений — только ваш браузер.
 
 Работает на устройствах **Kindle** и **Kobo** с установленным KOReader.
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | Декодирование URL, разбор строк запроса |
 
 При добавлении новой функциональности, пожалуйста, добавляйте соответствующие тесты для функций чистой логики.
+
+## Участники
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## Поддержать
+
+Если FileSync экономит ваше время, вы можете угостить меня кофе. Всегда приятно, но совершенно не обязательно.
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## Лицензия
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -2,6 +2,10 @@
 
 [English](README.md) | [Español](README.es.md) | [Português](README.pt_BR.md) | **中文** | [العربية](README.ar.md) | [Français](README.fr.md) | [Deutsch](README.de.md) | [Русский](README.ru.md) | [日本語](README.ja.md) | [한국어](README.ko.md)
 
+<p align="center">
+  <a href="https://ko-fi.com/abrahamnm"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" height="36"></a>
+</p>
+
 一款 KOReader 插件，可在电子阅读器上启动本地 Web 服务器并在屏幕上显示 QR 码。用手机扫描即可打开精美的 Web 界面，无线管理书籍和文件——无需数据线，无需安装应用，只需浏览器即可。
 
 支持运行 KOReader 的 **Kindle** 和 **Kobo** 设备。
@@ -255,6 +259,20 @@ busted spec/json_spec.lua
 | `spec/httpserver_spec.lua` | URL 解码、查询字符串解析 |
 
 添加新功能时，请为纯逻辑函数编写相应的测试。
+
+## 贡献者
+
+<a href="https://github.com/abrahamnm/filesync.koplugin/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=abrahamnm/filesync.koplugin" />
+</a>
+
+## 支持
+
+如果 FileSync 为你节省了时间，欢迎请我喝杯咖啡。心意随缘，绝不强求。
+
+<a href="https://ko-fi.com/abrahamnm">
+  <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Ko-fi" />
+</a>
 
 ## 许可证
 


### PR DESCRIPTION
Adds two new sections to all 10 translated READMEs, plus GitHub's native funding config.

## Changes

**Contributors section** — renders the contributor avatars via contrib.rocks, linked to the repo's contributors graph.

**Support section** — a Ko-fi button with a short localized line ("always appreciated, never expected"). Headings and copy are translated per language: Apoyar, Apoie, 支持, الدعم, Soutenir, Unterstützen, Поддержать, サポート, 후원.

**Ko-fi button near the top** — a centered button directly under the language switcher in each README, so it's visible without scrolling. The fuller Support section stays at the bottom so the project description and screenshots still come first.

**`.github/FUNDING.yml`** — makes GitHub render a Sponsor button in the repo sidebar and on every issue and pull request.

## Notes

Both badge images are third-party assets (contrib.rocks and ko-fi.com). GitHub proxies them through Camo so they render fine, but they are external dependencies — easy to swap for shields.io badges or plain links if that's a concern.